### PR TITLE
Allow all parameters to be read from environment variables

### DIFF
--- a/puppet6-bootstrap.sh
+++ b/puppet6-bootstrap.sh
@@ -38,9 +38,9 @@ if [ -z "$PP_ENVIRONMENT$PP_SERVICE$PP_ROLE" ]; then
     fi
 fi
 echo "Extended certificate attributes:"
-echo "\tpp_environment: $PP_ENVIRONMENT"
-echo "\tpp_service: $PP_SERVICE"
-echo "\tpp_role: $PP_ROLE"
+echo "  pp_environment: $PP_ENVIRONMENT"
+echo "  pp_service: $PP_SERVICE"
+echo "  pp_role: $PP_ROLE"
 
 # Download and install puppet
 mkdir setup-temp

--- a/puppet6-bootstrap.sh
+++ b/puppet6-bootstrap.sh
@@ -90,7 +90,7 @@ fi
 # Initial puppet run!
 /opt/puppetlabs/bin/puppet agent -t
 
-if [ ! -z "$WAIT_FOR_SIGN" ]; then
+if [ -z "$NO_WAIT_FOR_SIGN" ]; then
     echo "Sign and classify the node on the puppet master, then press enter"
     read dummy
 

--- a/puppet6-bootstrap.sh
+++ b/puppet6-bootstrap.sh
@@ -29,7 +29,7 @@ if [ -z "$PUPPETENV" ]; then
 fi
 echo "Using puppet environment: $PUPPETENV"
 
-if [ -z "$PP_ENVIRONMENT$PP_SERVICE$PP_ROLE"]; then
+if [ -z "$PP_ENVIRONMENT$PP_SERVICE$PP_ROLE" ]; then
     read -p "Set extra certificate attributes? [y/N]:" SET_EXTRA_ATTRIBUTES
     if [ $SET_EXTRA_ATTRIBUTES ] && [ ${SET_EXTRA_ATTRIBUTES,,} == "y" ]; then
     	read -p "pp_environment: " PP_ENVIRONMENT

--- a/puppet6-bootstrap.sh
+++ b/puppet6-bootstrap.sh
@@ -80,7 +80,7 @@ export PATH=$PATH:/opt/puppetlabs/bin
 /opt/puppetlabs/bin/puppet config --section agent set environment $PUPPETENV
 
 # If we're setting extra cert attributes, do that now
-if [ $SET_EXTRA_ATTRIBUTES ] && [ ${SET_EXTRA_ATTRIBUTES,,} == "y" ]; then
+if [ ! -z "$PP_ENVIRONMENT$PP_SERVICE$PP_ROLE" ]; then
 	echo "extension_requests:" >> /etc/puppetlabs/puppet/csr_attributes.yaml
 	[ $PP_ENVIRONMENT ] && echo "    pp_environment: $PP_ENVIRONMENT" >> /etc/puppetlabs/puppet/csr_attributes.yaml
 	[ $PP_SERVICE ] && echo "    pp_service: $PP_SERVICE" >> /etc/puppetlabs/puppet/csr_attributes.yaml


### PR DESCRIPTION
Allows `puppet6-boostrap.sh` to be run non-interactively (for example, from `cloud-init`). If set, the following environment variables are used:
- `NEWHOSTNAME`
- `PUPPETMASTER`
- `MASTERPORT`
- `PUPPETENV`
- `PP_ENVIRONMENT`
- `PP_SERVICE`
- `PP_ROLE`
- `NO_WAIT_FOR_SIGN` (if set, don't prompt to wait for the node to be signed)