### PR TITLE
Enable Puppet service via systemctl rather than puppet

### DIFF
--- a/puppet6-rpi-bootstrap.sh
+++ b/puppet6-rpi-bootstrap.sh
@@ -122,4 +122,4 @@ puppet agent --enable
 puppet agent -t
 
 # Enable the service
-puppet resource service puppet ensure=running enable=true
+systemctl enable puppet.service


### PR DESCRIPTION
On the Pi (where we build Puppet from source), the puppet service enable command doesn't seem to know how to do that. So let's use systemctl to enable the unit instead.