### PR TITLE
puppet6-rpi-bootstrap.sh: use "gem install puppet"

### DIFF
--- a/puppet6-rpi-bootstrap.sh
+++ b/puppet6-rpi-bootstrap.sh
@@ -52,6 +52,9 @@ apt-get install ruby-full -y || exit 1
 
 gem install puppet --version '~> 6' --no-rdoc --no-ri
 
+# We do need to create the puppet.conf file ourselves
+mkdir -p /etc/puppetlabs/puppet/
+touch /etc/puppetlabs/puppet/puppet.conf
 
 # Create the systemd service
 cat <<EOF > /lib/systemd/system/puppet.service

--- a/puppet6-rpi-bootstrap.sh
+++ b/puppet6-rpi-bootstrap.sh
@@ -50,7 +50,7 @@ cd setup-temp
 apt-get update || exit 1
 apt-get install ruby-full -y || exit 1
 
-gem install puppet --version '~> 6'
+gem install puppet --version '~> 6' --no-rdoc --no-ri
 
 
 # Create the systemd service

--- a/puppet6-rpi-bootstrap.sh
+++ b/puppet6-rpi-bootstrap.sh
@@ -103,16 +103,8 @@ puppet module install puppetlabs-yumrepo_core --target-dir /opt/puppetlabs/puppe
 puppet module install puppetlabs-zfs_core --target-dir /opt/puppetlabs/puppet/vendor_modules/
 puppet module install puppetlabs-zone_core --target-dir /opt/puppetlabs/puppet/vendor_modules/
 
-puppet agent -t
-
-echo 'Sign this node on the server and press [enter] here when done...'
-read dummy
-
-# Enable puppet
-puppet agent --enable
-
-# Run it for reals
-puppet agent -t
+# First puppet run. Will attempt to get signed certificate from master every 30s.
+puppet agent -t --waitforcert 30
 
 # Enable the service
 systemctl enable puppet.service

--- a/puppet6-rpi-bootstrap.sh
+++ b/puppet6-rpi-bootstrap.sh
@@ -48,17 +48,10 @@ mkdir setup-temp
 cd setup-temp
 
 apt-get update || exit 1
-apt-get install ruby-full facter hiera unzip build-essential -y || exit 1
-gem install bundler
-gem install semantic_puppet
+apt-get install ruby-full -y || exit 1
 
-wget https://github.com/puppetlabs/puppet/archive/6.4.0.tar.gz || exit 1
-tar xzf 6.4.0.tar.gz || exit 1
-cd puppet-6.4.0
+gem install puppet --version '~> 6'
 
-bundle install --path .bundle/gems || exit 1
-bundle update || exit 1
-ruby install.rb || exit 1
 
 # Create the systemd service
 cat <<EOF > /lib/systemd/system/puppet.service

--- a/puppet6-rpi-bootstrap.sh
+++ b/puppet6-rpi-bootstrap.sh
@@ -42,10 +42,7 @@ echo "  pp_environment: $PP_ENVIRONMENT"
 echo "  pp_service: $PP_SERVICE"
 echo "  pp_role: $PP_ROLE"
 
-echo "Thanks. Beginning set up. This compiles from source so will likely take a long time..."
-# add puppet repo
-mkdir setup-temp
-cd setup-temp
+echo "Thanks. Beginning set up. This may take some time..."
 
 apt-get update || exit 1
 apt-get install ruby-full -y || exit 1


### PR DESCRIPTION
Use "gem install puppet" rather than downloading an archive of the source code.

* The main advantage is that we can then automatically get the latest 6.x version (rather than hardcoding a specific version) 
* It's probably also making things a bit cleaner because we don't need to worry about dependencies. They will be installed.
* We might even be able to easily upgrade puppet later on using `gem upgrade puppet`

Also stop prompting the user to sign the cert on the master. Instead we just run `puppet agent -t --waitforcert 30` so that puppet check for the sign certificate every 30s. (similar to what we do for `puppet6-bootstrap.sh`. That's one less manual step)