### PR TITLE
Configure the certname in puppet.conf

### DIFF
--- a/puppet6-bootstrap.sh
+++ b/puppet6-bootstrap.sh
@@ -149,12 +149,14 @@ export PATH=$PATH:/opt/puppetlabs/bin
 
 /opt/puppetlabs/bin/puppet config set server $PUPPETMASTER --section main
 
-
 /opt/puppetlabs/bin/puppet config set masterport $MASTERPORT --section main
 
 # Set the environment
 
 /opt/puppetlabs/bin/puppet config --section agent set environment $PUPPETENV
+
+# Set the certname so we don't re-generate the certificate request if our DNS suffix changes
+/opt/puppetlabs/bin/puppet config set certname $NEWHOSTNAME --section main
 
 # If we're setting extra cert attributes, do that now
 if [ ! -z "$PP_ENVIRONMENT$PP_SERVICE$PP_ROLE" ]; then

--- a/puppet6-rpi-bootstrap.sh
+++ b/puppet6-rpi-bootstrap.sh
@@ -83,6 +83,8 @@ puppet config set server $PUPPETMASTER --section main || exit 1
 
 puppet config set masterport $MASTERPORT --section main
 
+puppet config set certname $NEWHOSTNAME --section main
+
 puppet config set environment $PUPPETENV --section agent || exit 1
 
 # If we're setting extra cert attributes, do that now


### PR DESCRIPTION
This explicitly sets `certname` in the Puppet config.

At the moment, if the system FQDN changes (for example, a Raspberry Pi on a new wireless network), Puppet may decide to generate a new CSR using the new DNS suffix.

This way, we always stick with the expected FQDN for the life of the node.