### PR TITLE
pin windows puppet installs to 6.13.0

### DIFF
--- a/puppet6-bootstrap.ps1
+++ b/puppet6-bootstrap.ps1
@@ -32,9 +32,9 @@ if(Get-Command puppet -ErrorAction 0) {
 }
 
 if( [Environment]::Is64BitOperatingSystem ) {
-    $MsiUrl = 'https://downloads.puppetlabs.com/windows/puppet6/puppet-agent-x64-latest.msi'
+    $MsiUrl = 'https://downloads.puppetlabs.com/windows/puppet6/puppet-agent-6.13.0-x64.msi'
 } else {
-    $MsiUrl = 'https://downloads.puppetlabs.com/windows/puppet6/puppet-agent-x86-latest.msi'
+    $MsiUrl = 'https://downloads.puppetlabs.com/windows/puppet6/puppet-agent-6.13.0-x86.msi'
 }
 
 $currentPrincipal = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())


### PR DESCRIPTION
This pins the Windows puppet install to version 6.13.0 because 6.14.0 breaks downloading files over HTTPS with `file { }` resources.

See https://tickets.puppetlabs.com/browse/PUP-10365

Should be fixed in 6.15.0 so we can revisit then. 